### PR TITLE
Set correct title for television seasons

### DIFF
--- a/wikidata_new_from_wikipedia_query_article.py
+++ b/wikidata_new_from_wikipedia_query_article.py
@@ -335,7 +335,11 @@ for prefix in wikipedias:
 		# Remove trailing brackets from the page title
 		page_title = page.title()
 		if page_title[-1] == ')':
-			page_title = page_title[:page_title.rfind('(')]
+			bracketIndex = page_title.rfind('(')
+			if 'season ' in page_title[bracketIndex:]:
+				page_title = page_title[:bracketIndex-1]+', '+page_title[bracketIndex+1:-1]
+			else:
+				page_title = page_title[:bracketIndex]
 		page_title = page_title.strip()
 		# If we're here, then create a new item
 		if prefix == 'simple':


### PR DESCRIPTION
Introduce a conditional check for 'season' presence within brackets, improving handling for the creation of television season items.

Background:
https://www.wikidata.org/wiki/User_talk:Mike_Peel#Pi_bot_and_television_seasons
If the bot creates items from television season wikipedia articles, the title of the series was always set as title of the item. So something like "FBI (season 5)" would become "FBI" at Wikidata. This PR changes the title to the correct form "FBI, season 5".